### PR TITLE
Pass prop isActiveTab onto each child view

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ const ScrollableTabView = React.createClass({
             return <View
               key={child.props.tabLabel + '_' + idx}
               style={{width: this.state.containerWidth, }}>
-              {child}
+              { React.cloneElement(child, { isActiveTab:(idx === this.state.currentPage)}) }
             </View>;
           })}
         </ScrollView>
@@ -135,7 +135,7 @@ const ScrollableTabView = React.createClass({
            return <View
              key={child.props.tabLabel + '_' + idx}
              style={{width: this.state.containerWidth, }}>
-             {child}
+             { React.cloneElement(child, { isActiveTab:(idx === this.state.currentPage)}) }
            </View>;
          })}
         </ViewPagerAndroid>


### PR DESCRIPTION
Gives child views an easy way to update themselves each time they
are shown. This is possible to do without this modification, if a state
is kept in the parent of the tabview and wired to each child manually,
the point of this PR is to automate this and reduce that overhead.
