### PR TITLE
Pass all child props to tabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,6 +252,7 @@ const ScrollableTabView = React.createClass({
     let overlayTabs = (this.props.tabBarPosition === 'overlayTop' || this.props.tabBarPosition === 'overlayBottom');
     let tabBarProps = {
       goToPage: this.goToPage,
+      tabProps: this._children().map((child) => child.props),
       tabs: this._children().map((child) => child.props.tabLabel),
       activeTab: this.state.currentPage,
       scrollValue: this.state.scrollValue,


### PR DESCRIPTION
Allows you to pass / access any prop though tabProps[i]. This allows more flexibility in custom TabBars. 

For example, different color per tabs, notifications on tabs, etc..
