### PR TITLE
avoid update an constructed tab page, (reduce frame drop) by just keep clicking around the tab bar button fast

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ const ScrollableTabView = React.createClass({
       scrollValue: new Animated.Value(this.props.initialPage),
       containerWidth: Dimensions.get('window').width,
       sceneKeys: this.newSceneKeys({ currentPage: this.props.initialPage, }),
+      previousKeys : [],
     };
   },
 
@@ -110,7 +111,8 @@ const ScrollableTabView = React.createClass({
 
   updateSceneKeys({ page, children = this.props.children, callback = () => {}, }) {
     let newKeys = this.newSceneKeys({ previousKeys: this.state.sceneKeys, currentPage: page, children, });
-    this.setState({currentPage: page, sceneKeys: newKeys, }, callback);
+    let previousKeys = JSON.parse(JSON.stringify(this.state.sceneKeys));
+    this.setState({currentPage: page, sceneKeys: newKeys, previousKeys : previousKeys }, callback);
   },
 
   newSceneKeys({ previousKeys = [], currentPage = 0, children = this.props.children, }) {
@@ -191,7 +193,7 @@ const ScrollableTabView = React.createClass({
       let key = this._makeSceneKey(child, idx);
       return <SceneComponent
         key={child.key}
-        shouldUpdated={this._shouldRenderSceneKey(idx, this.state.currentPage)}
+        shouldUpdated={this._shouldRenderSceneKey(idx, this.state.currentPage) && !this._keyExists(this.state.previousKeys,idx) }
         style={{width: this.state.containerWidth, }}
       >
         {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ const ScrollableTabView = React.createClass({
       containerWidth: Dimensions.get('window').width,
       sceneKeys: this.newSceneKeys({ currentPage: this.props.initialPage, }),
       previousKeys : [],
+      updateByPageChange : false,
     };
   },
 
@@ -100,6 +101,7 @@ const ScrollableTabView = React.createClass({
     this.updateSceneKeys({
       page: pageNumber,
       callback: this._onChangeTab.bind(this, currentPage, pageNumber),
+      updateByPageChange: true,
     });
   },
 
@@ -113,7 +115,7 @@ const ScrollableTabView = React.createClass({
     }
   },
 
-  updateSceneKeys({ page, children = this.props.children, callback = () => {}, }) {
+  updateSceneKeys({ page, children = this.props.children, callback = () => {}, updateByPageChange = false }) {
     let newKeys = this.newSceneKeys({ previousKeys: this.state.sceneKeys, currentPage: page, children, });
     let previousKeys = JSON.parse(JSON.stringify(this.state.sceneKeys));
     this.setState({currentPage: page, sceneKeys: newKeys, previousKeys : previousKeys }, callback);
@@ -199,7 +201,9 @@ const ScrollableTabView = React.createClass({
       return <SceneComponent
         key={child.key}
         shouldUpdated={this._shouldRenderSceneKey(idx, this.state.currentPage) &&
-                       (this.props.forceUpdateOnPageChanged || !this._keyExists(this.state.previousKeys,key)) }
+                       (this.props.forceUpdateOnPageChanged || 
+                       !this._keyExists(this.state.previousKeys,key) ||
+                       !this.state.updateByPageChange ) }
         style={{width: this.state.containerWidth, }}
       >
         {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}
@@ -225,6 +229,7 @@ const ScrollableTabView = React.createClass({
     this.updateSceneKeys({
       page: localNextPage,
       callback: this._onChangeTab.bind(this, currentPage, localNextPage),
+      updateByPageChange: true,
     });
   },
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ const ScrollableTabView = React.createClass({
     scrollWithoutAnimation: PropTypes.bool,
     locked: PropTypes.bool,
     prerenderingSiblingsNumber: PropTypes.number,
+    forceUpdateOnPageChanged: PropTypes.bool,
+    bounces:PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -53,6 +55,8 @@ const ScrollableTabView = React.createClass({
       scrollWithoutAnimation: false,
       locked: false,
       prerenderingSiblingsNumber: 0,
+      forceUpdateOnPageChanged: true,
+      bounces: true
     };
   },
 
@@ -162,6 +166,7 @@ const ScrollableTabView = React.createClass({
         scrollEnabled={!this.props.locked}
         directionalLockEnabled
         alwaysBounceVertical={false}
+        bounces = {this.props.bounces}
         keyboardDismissMode="on-drag"
         {...this.props.contentProps}
       >
@@ -193,7 +198,8 @@ const ScrollableTabView = React.createClass({
       let key = this._makeSceneKey(child, idx);
       return <SceneComponent
         key={child.key}
-        shouldUpdated={this._shouldRenderSceneKey(idx, this.state.currentPage) && !this._keyExists(this.state.previousKeys,idx) }
+        shouldUpdated={this._shouldRenderSceneKey(idx, this.state.currentPage) &&
+                       (this.props.forceUpdateOnPageChanged || !this._keyExists(this.state.previousKeys,idx)) }
         style={{width: this.state.containerWidth, }}
       >
         {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ const ScrollableTabView = React.createClass({
       return <SceneComponent
         key={child.key}
         shouldUpdated={this._shouldRenderSceneKey(idx, this.state.currentPage) &&
-                       (this.props.forceUpdateOnPageChanged || !this._keyExists(this.state.previousKeys,idx)) }
+                       (this.props.forceUpdateOnPageChanged || !this._keyExists(this.state.previousKeys,key)) }
         style={{width: this.state.containerWidth, }}
       >
         {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}


### PR DESCRIPTION
background:
If you have four tabs, each tab have four scrollview with some photos on each tab.
It will have some frame drop on js side when you press the tab button, if you tab around the tab bar buttons fast enough, the frame rate can drop to zero (very undesirable) . Swiping back and forth around your tab page produce the same frame drop, too. This is because every time you go to another tab page, no matter it is a new construct of a tab page or going to an existing one,  it will fire a render of the whole tab content, the staticContainer's shouldUpdated prop will set to true (componentWillReceiveProps() will be called on the tab content, this may be very expensive if you have some heavy logic there, like checking a datasource for updated rows,etc. ). Updating the tab content props is not the behavior wanted for an already existing page when you pressing around tab bar button. (feels like every time you click on a tab of chome browser, it refresh the page.  )

Solution
This code will render the page once to construct it, afterward it will stay there. No more re-render caused by just a press on a tab bar button.
