### PR TITLE
Removing ref='tabContainer'

### DIFF
--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -179,7 +179,6 @@ const ScrollableTabBar = createReactClass({
       >
         <View
           style={[styles.tabs, {width: this.state._containerWidth, }, this.props.tabsContainerStyle, ]}
-          ref={'tabContainer'}
           onLayout={this.onTabContainerLayout}
         >
           {this.props.tabs.map((name, page) => {


### PR DESCRIPTION
Removing ref='tabContainer' since this causes Refs must have owners error. 
https://reactjs.org/warnings/refs-must-have-owner.html#strings-refs-outside-the-render-method 
Plus this ref is not being used anywhere. 

Testing:
Tested if the component still works. Verified scrolling tabs works, and was able to navigate to the tab by clicking on the tab label.