### PR TITLE
withoutAnimation in a custom tabbar

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,15 +126,16 @@ const ScrollableTabView = createReactClass({
     }
   },
 
-  goToPage(pageNumber) {
+  goToPage(pageNumber, scrollWithoutAnimation) {
+	scrollWithoutAnimation = (this.props.scrollWithoutAnimation && scrollWithoutAnimation) || false;
     if (Platform.OS === 'ios') {
       const offset = pageNumber * this.state.containerWidth;
       if (this.scrollView) {
-        this.scrollView.getNode().scrollTo({x: offset, y: 0, animated: !this.props.scrollWithoutAnimation, });
+        this.scrollView.getNode().scrollTo({x: offset, y: 0, animated: !scrollWithoutAnimation });
       }
     } else {
       if (this.scrollView) {
-        if (this.props.scrollWithoutAnimation) {
+        if (scrollWithoutAnimation) {
           this.scrollView.getNode().setPageWithoutAnimation(pageNumber);
         } else {
           this.scrollView.getNode().setPage(pageNumber);

--- a/index.js
+++ b/index.js
@@ -126,12 +126,15 @@ const ScrollableTabView = createReactClass({
     }
   },
 
-  goToPage(pageNumber, scrollWithoutAnimation) {
-	scrollWithoutAnimation = (this.props.scrollWithoutAnimation && scrollWithoutAnimation) || false;
+  goToPage(pageNumber, scrollWithoutAnimationParam) {
+    const scrollWithoutAnimation = scrollWithoutAnimationParam === undefined ?
+      this.props.scrollWithoutAnimation :
+      scrollWithoutAnimationParam;
+
     if (Platform.OS === 'ios') {
       const offset = pageNumber * this.state.containerWidth;
       if (this.scrollView) {
-        this.scrollView.getNode().scrollTo({x: offset, y: 0, animated: !scrollWithoutAnimation });
+        this.scrollView.getNode().scrollTo({x: offset, y: 0, animated: !scrollWithoutAnimation, });
       }
     } else {
       if (this.scrollView) {
@@ -333,7 +336,7 @@ const ScrollableTabView = createReactClass({
     if (!width || width <= 0 || Math.round(width) === Math.round(this.state.containerWidth)) {
       return;
     }
-    
+
     if (Platform.OS === 'ios') {
       const containerWidthAnimatedValue = new Animated.Value(width);
       // Need to call __makeNative manually to avoid a native animated bug. See

--- a/index.js
+++ b/index.js
@@ -126,11 +126,7 @@ const ScrollableTabView = createReactClass({
     }
   },
 
-  goToPage(pageNumber, scrollWithoutAnimationParam) {
-    const scrollWithoutAnimation = scrollWithoutAnimationParam === undefined ?
-      this.props.scrollWithoutAnimation :
-      scrollWithoutAnimationParam;
-
+  goToPage(pageNumber, scrollWithoutAnimation = this.props.scrollWithoutAnimation) {
     if (Platform.OS === 'ios') {
       const offset = pageNumber * this.state.containerWidth;
       if (this.scrollView) {


### PR DESCRIPTION
Now you can goToPage without animation for a specific tab when you use a custom tab bar like this:
````js
const TabBar = ({ activeTab, goToPage, levels }: TabBarProps) => {
  const withoutAnimation = activeTab === 0 || activeTab === 1;
  return (
    <ScrollView
      horizontal
      showsHorizontalScrollIndicator={false}
    >
      <Tab
        onPress={() => goToPage(0, withoutAnimation)}
        name="All"
      />
      <Tab
        onPress={() => goToPage(1, withoutAnimation)}
        name="Others"
      />
    </ScrollView>
  );
}
````
or just like this:
```js
    goToPage(1, true)
```