### PR TITLE
Fix underline not showing up on screen load

### DIFF
--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -148,7 +148,7 @@ const ScrollableTabBar = createReactClass({
   measureTab(page, event) {
     const { x, width, height, } = event.nativeEvent.layout;
     this._tabsMeasurements[page] = {left: x, right: x + width, width, height, };
-    this.updateView({value: this.props.scrollValue._value, });
+    this.updateView({value:  this.props.scrollValue.__getValue(), });
   },
 
   render() {
@@ -207,12 +207,12 @@ const ScrollableTabBar = createReactClass({
       width = WINDOW_WIDTH;
     }
     this.setState({ _containerWidth: width, });
-    this.updateView({value: this.props.scrollValue._value, });
+    this.updateView({value: this.props.scrollValue.__getValue(), });
   },
 
   onContainerLayout(e) {
     this._containerMeasurements = e.nativeEvent.layout;
-    this.updateView({value: this.props.scrollValue._value, });
+    this.updateView({value: this.props.scrollValue.__getValue(), });
   },
 });
 


### PR DESCRIPTION
Fix for https://github.com/happypancake/react-native-scrollable-tab-view/issues/845